### PR TITLE
Handle period-specific cancellation fees

### DIFF
--- a/app/dbconnection.py
+++ b/app/dbconnection.py
@@ -742,20 +742,24 @@ def get_court_rates_per_minute():
             rows = cursor.fetchall()
 
             for row in rows:
-                rates = [row.RATEPMIN1, row.RATEPMIN2, row.RATEPMIN3, row.RATEPMIN4, row.RATEPMIN5]
-                bookings = [row.IBOOKING1, row.IBOOKING2, row.IBOOKING3, row.IBOOKING4, row.IBOOKING5]
-                cancellations = [row.ICANCEL1, row.ICANCEL2, row.ICANCEL3, row.ICANCEL4, row.ICANCEL5]
+                rates = [
+                    round(r, 4) if r is not None else None
+                    for r in [row.RATEPMIN1, row.RATEPMIN2, row.RATEPMIN3, row.RATEPMIN4, row.RATEPMIN5]
+                ]
+                bookings = [
+                    b if b is not None else None
+                    for b in [row.IBOOKING1, row.IBOOKING2, row.IBOOKING3, row.IBOOKING4, row.IBOOKING5]
+                ]
+                cancellations = [
+                    c if c is not None else None
+                    for c in [row.ICANCEL1, row.ICANCEL2, row.ICANCEL3, row.ICANCEL4, row.ICANCEL5]
+                ]
 
-                valid_rates = [round(r, 4) for r in rates if r not in (0, None)]
-                valid_bookings = [b for b in bookings if b not in (0, None)]
-                valid_cancellations = [c for c in cancellations if c not in (0, None)]
-
-                if valid_rates or valid_bookings or valid_cancellations:
-                    court_data[row.CourtDesc] = {
-                        "rates": valid_rates,
-                        "bookings": valid_bookings,
-                        "cancellations": valid_cancellations
-                    }
+                court_data[row.CourtDesc] = {
+                    "rates": rates,
+                    "bookings": bookings,
+                    "cancellations": cancellations,
+                }
             return court_data
     except pyodbc.Error as e:
         print("Error accessing the database:", e)

--- a/app/flask_bookings_app.py
+++ b/app/flask_bookings_app.py
@@ -542,8 +542,9 @@ def delete_booking():
         player_no_column = data.get("player_no_column")  # e.g., "PlayerNo_1"
         player_no = data.get("player_no")  # Member number
         selected_court = data.get("selected_court")  # Court ID or number
+        period_id = data.get("period_id")  # Booking period identifier
 
-        if not (date_container and slot_id and player_no_column and player_no and selected_court):
+        if not (date_container and slot_id and player_no_column and player_no and selected_court and period_id):
             return jsonify({"error": "Missing booking details."}), 400
 
         try:
@@ -587,7 +588,7 @@ def delete_booking():
             print(f"[ERROR] Failed to process waiting list notifications: {e}")
 
         # Step 4: Call the financial update
-        financial_result = delete_booking_financials(player_no)
+        financial_result = delete_booking_financials(player_no, period_id)
         if financial_result["status"] == "error":
             return jsonify({
                 "message": "Booking deleted, but financial update failed.",
@@ -618,16 +619,20 @@ def delete_booking():
         except Exception as e:
             print(f"[ERROR] Audit log failed: {e}")
 
-def delete_booking_financials(player_no):
+def delete_booking_financials(player_no, period_id):
     """
     Perform the financial update for a successful cancellation.
     Updates the S_Credit in the database.
+
+    Args:
+        player_no (int): Member number of the player.
+        period_id (int): Booking period identifier to select the correct cancellation fee.
     """
     try:
         from flask import current_app, request
 
         # Construct the financial data payload
-        financial_payload = {"mem_no": player_no, "cost_type": "ICANCEL"}
+        financial_payload = {"mem_no": player_no, "cost_type": "ICANCEL", "period_id": period_id}
         print(f"[DEBUG] Financial payload for cancellation: {financial_payload}")  # Log payload for debugging
 
         # Construct the financial endpoint dynamically

--- a/app/static/bookings.js
+++ b/app/static/bookings.js
@@ -374,12 +374,23 @@ function deleteBookingFromServer(selectedDate, slotId, playerNo, row, clickedCel
             return;
         }
 
+        const periodId = parseInt(clickedCell.getAttribute("data-period-id"), 10);
+        if (isNaN(periodId)) {
+            showDebugPopup({
+                status: "error",
+                message: "Period ID not found for the selected booking.",
+                debug: { clickedCell },
+            });
+            return;
+        }
+
         const payload = {
             date_container: selectedDate,
             slot_id: slotId,
             player_no_column: `PlayerNo_${courtId}`,
             player_no: playerNo,
             selected_court: courtId,
+            period_id: periodId,
         };
 
         // Show the popup with additional debug information when booking was deleted


### PR DESCRIPTION
## Summary
- include period identifier when cancelling bookings on the client and server
- select the correct ICANCEL fee by period and allow zero-fee cancellations
- keep full court rate lists so period indexing remains intact

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68ad9c8211a083329cb0642924154137